### PR TITLE
Fix use after scope issue

### DIFF
--- a/lib/src/UrlEncoder.cpp
+++ b/lib/src/UrlEncoder.cpp
@@ -82,12 +82,11 @@ quicr::Namespace UrlEncoder::EncodeUrl(const std::string& url) const
     }
 
     // Skip the first group since its the whole match
-    std::string_view match;
     for (std::uint32_t i = 1; i < matches.size(); i++)
     {
-        match = matches[i].str();
-        std::uint16_t base = match.starts_with("0x") ? 16 : match.starts_with("0b") ? 2 : 10;
-        std::uint64_t val = std::stoull(match.data(), nullptr, base);
+        const std::sub_match match = matches[i];
+        std::uint16_t base = match.str().starts_with("0x") ? 16 : match.str().starts_with("0b") ? 2 : 10;
+        std::uint64_t val = std::stoull(match, nullptr, base);
         std::uint32_t bits = selected_template.bits[i - 1];
         if ((val & ~(~0x0ull << bits)) != val)
         {
@@ -292,10 +291,9 @@ void UrlEncoder::AddTemplate(const std::string& new_template, const bool overwri
     try
     {
         // Get the pen group value
-        std::string_view match;
-        match = matches[1].str();
-        std::uint16_t base = match.starts_with("0x") ? 16 : match.starts_with("0b") ? 2 : 10;
-        pen_value = std::stoul(match.data(), nullptr, base);
+        const std::ssub_match match = matches[1];
+        std::uint16_t base = match.str().starts_with("0x") ? 16 : match.str().starts_with("0b") ? 2 : 10;
+        pen_value = std::stoul(match.str(), nullptr, base);
     }
     catch (std::out_of_range& ex)
     {


### PR DESCRIPTION
I think there was a bug here that I found with `asan` where we're holding onto a string view that we shouldn't. Run the tests under asan and you'll see it. I'm not entirely sure, but I think we need to use this immediately, we can't store it. This seemed to make asan happy at least, but happy to defer to anyone who knows what they're doing. 